### PR TITLE
Add package.json for Unity to index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+	"name": "com.jiaquarium.unity-urp-2.5d-lit-shader",
+	"displayName": "Universal RP 2.5D Lit Sprite Shader",
+	"version": "0.0.0",
+	"author": {
+		"name": "Jiaquarium",
+		"url": "https://github.com/Jiaquarium"
+	},
+	"documentationUrl": "https://github.com/Jiaquarium/unity-URP-2.5D-lit-shader",
+	"keywords": ["shader", "urp", "2.5d", "sprite", "lighting", "depth", "shadow"]
+}


### PR DESCRIPTION
This commit adds a `package.json` in the root directory that makes the repository a valid package that can be put into a Unity project's `Packages/` folder and recognized by the engine.

The information written in the file is under total respect to the original author Jiaquarium.
Due to the absence of a license in the original repository, the `license` field is not included.
The version is set to `0.0.0` since there is not a clear version number in the repository.